### PR TITLE
Changed max compatibility in install.rdf

### DIFF
--- a/install.rdf
+++ b/install.rdf
@@ -49,7 +49,7 @@
 			       https://addons.mozilla.org/en-US/firefox/pages/appversions/
 			    -->
 			    <em:minVersion>3.6</em:minVersion>
-			    <em:maxVersion>5.*</em:maxVersion>
+			    <em:maxVersion>6.*</em:maxVersion>
 		    </Description>
 	    </em:targetApplication>
 	</Description>


### PR DESCRIPTION
Haven't done any exhaustive testing, but it seems to work on a few example pages exactly the same as Firefox 5.*
