### PR TITLE
Updated the maximum firefox version in install.rdf

### DIFF
--- a/install.rdf
+++ b/install.rdf
@@ -49,7 +49,7 @@
 			       https://addons.mozilla.org/en-US/firefox/pages/appversions/
 			    -->
 			    <em:minVersion>3.6</em:minVersion>
-			    <em:maxVersion>5.*</em:maxVersion>
+			    <em:maxVersion>7.*</em:maxVersion>
 		    </Description>
 	    </em:targetApplication>
 	</Description>

--- a/install.rdf
+++ b/install.rdf
@@ -10,7 +10,7 @@
 	    <!--
 	        Extension version.
 	    -->
-	    <em:version>0.9.7</em:version>
+	    <em:version>0.9.8</em:version>
 
 	    <!--
 	        Extension  type.
@@ -49,7 +49,7 @@
 			       https://addons.mozilla.org/en-US/firefox/pages/appversions/
 			    -->
 			    <em:minVersion>3.6</em:minVersion>
-			    <em:maxVersion>7.*</em:maxVersion>
+			    <em:maxVersion>8.*</em:maxVersion>
 		    </Description>
 	    </em:targetApplication>
 	</Description>


### PR DESCRIPTION
Currently, the plugin on addons.mozilla.org has the version cutoff at 5.x, but the current stable version is 6.0.  I bumped it up to 7.x (Aurora branch); and tested it in stable, beta, and aurora.  Everything appears to work fine still.

If you're fine with this, could you update the version that is on addons.mozilla.org as well?

Thanks,
Jonathan Palecek
