### PR TITLE
Remove trailing whitespace.

### DIFF
--- a/content/browser.js
+++ b/content/browser.js
@@ -84,24 +84,24 @@ var gCcHandler = {
 		content.document.location.href, doc_subject);
 	    let author_uri = ccffext.objects.getAuthorUri(
 		content.document.location.href, doc_subject);
-	    
-	    if ("undefined" != typeof author || 
+
+	    if ("undefined" != typeof author ||
 		"undefined" != typeof author_uri) {
-		
+
 		// at least one has been provided
 		this._popup_attribution.hidden = false;
-		
-		if ("undefined" == typeof author && 
+
+		if ("undefined" == typeof author &&
 		    "undefined" != typeof author_uri)
 		    author = author_uri;
-		
+
 		if ("undefined" != typeof author) {
 		    // attribution name was supplied
 		    this._popup_attribution.value = author;
 		}
-		
+
 		if ("undefined" != typeof author_uri) {
-		    this._popup_attribution.setAttribute('href', 
+		    this._popup_attribution.setAttribute('href',
 							 author_uri.uri);
 		    this._popup_attribution.setAttribute(
 			"class", "text-link");
@@ -110,15 +110,15 @@ var gCcHandler = {
 		    this._popup_attribution.setAttribute(
 			"class", "");
 		}
-	    } 
-	    
+	    }
+
 	} // if license is not undefined
 
 	// how many licensed objects described by this page, excluding the page
 	var count = ccffext.objects.getLicensedSubjects(
 	    content.document.location.href).length - (is_doc_licensed?1:0);
 	if (count > 0) {
-	    this._popup_num_licensed_objects.value = 
+	    this._popup_num_licensed_objects.value =
 		ccffext.l10n.get("icon.title.label", count);
 	    this._popup_num_licensed_objects.hidden = false;
 	}
@@ -133,7 +133,7 @@ var gCcHandler = {
 
     handleMoreInfo : function(e) {
 	gCcHandler.hidePopup();
-	BrowserPageInfo(null,'ccffext-tab'); 
+	BrowserPageInfo(null,'ccffext-tab');
     },
 
     handleCopyHtml : function(e) {
@@ -141,7 +141,7 @@ var gCcHandler = {
 	    getService(Components.interfaces.nsIClipboardHelper);
 	clipboard.copyString(
 	    ccffext.objects.getAttributionHtml(
-		content.document.location.href, 
+		content.document.location.href,
 		{'uri':content.document.location.href}));
 
 	// close the popup
@@ -153,7 +153,7 @@ var gCcHandler = {
 	    getService(Components.interfaces.nsIClipboardHelper);
 	clipboard.copyString(
 	    ccffext.objects.getAttributionText(
-		content.document.location.href, 
+		content.document.location.href,
 		{'uri':content.document.location.href}));
 
 	// close the popup
@@ -168,7 +168,7 @@ var gCcHandler = {
     hideIcon : function() {
 	this._icon.hidden = true;
     },
-    
+
     showIcon : function(document) {
 	const objects = ccffext.objects.getLicensedSubjects(
 	    document.location.href);
@@ -192,9 +192,9 @@ var gCcHandler = {
 
 	if (document instanceof HTMLDocument) {
 	    ccffext.objects.callbackify(
-		document, 
+		document,
 		function(document,objects) {
-		    if (gBrowser.contentDocument == document) 
+		    if (gBrowser.contentDocument == document)
 			gCcHandler.showIcon(document);
 		},
 		function(document) {
@@ -207,15 +207,15 @@ var gCcHandler = {
 
 /**
  *  Register window load listener which adds event listeners for tab,
- *  location, and state changes. 
+ *  location, and state changes.
  **/
 window.addEventListener("load",function() {
 
     gBrowser.addEventListener(
-	"TabSelect", 
+	"TabSelect",
 	function(e) { gCcHandler.showIconIfLicenseInfo();}, false);
     gBrowser.tabContainer.addEventListener(
-	"TabSelect", 
+	"TabSelect",
 	function(e) { gCcHandler.showIconIfLicenseInfo();}, false);
 
     gBrowser.addTabsProgressListener({
@@ -224,23 +224,23 @@ window.addEventListener("load",function() {
 	    // A tab is opened, closed, or switched to
 	    // Show the location bar icon if license information is present
 
-	    // XXX disabling; this is called before the browser fully 
+	    // XXX disabling; this is called before the browser fully
 	    // -- loads the document, causing errors in the parse process
 	    // gCcHandler.showIconIfLicenseInfo(progress.DOMWindow.document);
 
 	},
-	
+
 	onStateChange : function(browser, progress,request,flag,status) {
-	    
+
 	    // A document in an existing tab stopped loading
 	    if (flag & Components.interfaces.nsIWebProgressListener.STATE_STOP)
 	    {
 		const doc = progress.DOMWindow.document;
-		
+
 		gCcHandler.showIconIfLicenseInfo(progress.DOMWindow.document);
 	    }
 	},
-	
+
     });
 
     licenses.init(gCcHandler._license_browser);

--- a/content/browser.xul
+++ b/content/browser.xul
@@ -8,7 +8,7 @@
 	 xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
 
   <!-- Bootstrap scripts -->
-  <script type="text/javascript" 
+  <script type="text/javascript"
 	  src="resource://ccffext/bootstrap.js"></script>
 
   <!-- Control the main browser window behavior -->
@@ -16,7 +16,7 @@
 	  src="chrome://ccffext/content/browser.js"></script>
 
   <!-- First run handling -->
-  <script type="text/javascript" 
+  <script type="text/javascript"
 	  src="chrome://ccffext/content/firstrun.js"></script>
 
   <!-- CC urlbar icon -->
@@ -24,11 +24,11 @@
     <image id="ccffext-icon" hidden="true"
 	   onclick="gCcHandler.handleIconClick(event)" />
   </hbox>
-  
+
   <!-- CC License popup -->
   <popupset id="mainPopupSet">
     <!-- Popup for site license information -->
-    <panel id="ccffext-popup" position="after_start" 
+    <panel id="ccffext-popup" position="after_start"
 	   hidden="true" noautofocus="true"
 	   onpopupshown="document.getElementById('ccffext-popup-more-info-button').focus();"
 	   level="top">
@@ -42,16 +42,16 @@
 		 href="" />
 	  <label id="ccffext-popup-license-link"
                  class="text-link"
-                 value="" 
+                 value=""
 		 href="" />
 	  <label id="ccffext-popup-licensed-objects"
 		 value="" />
 	  <hbox>
 	    <button type="menu" label="Copy Attribution">
 	      <menupopup>
-		<menuitem label="as HTML" 
+		<menuitem label="as HTML"
 			  oncommand="gCcHandler.handleCopyHtml(event);"/>
-		<menuitem label="as Plain Text" 
+		<menuitem label="as Plain Text"
 			  oncommand="gCcHandler.handleCopyText(event);"/>
 	      </menupopup>
 	    </button>
@@ -64,7 +64,7 @@
       <box id="ccffext-popup-license-band" flex="1" />
       <browser id="ccffext-license-frame" name="ccffext-license-frame"
 	       type="content" height="0" width="0" />
-      
+
     </panel>
   </popupset>
 

--- a/content/firstrun.js
+++ b/content/firstrun.js
@@ -2,8 +2,8 @@ var Prefs = Components.classes["@mozilla.org/preferences-service;1"].getService(
 Prefs = Prefs.getBranch("extensions.ccffext.");
 
 var Overlay = {
-	
-  init: function(){ 
+
+  init: function(){
 
 
       var ver = -1, firstrun = true;
@@ -29,14 +29,14 @@ var Overlay = {
 			  return true;
 		      }
 		  }];
-				
+
 		  nb.appendNotification(
 		      "You've installed OpenAttribute, an add-on that helps you find CC licensed works and properly attribute them.",
 		      'installed-oa',
 		      'chrome://ccffext/skin/icon32.png',
 		      nb.PRIORITY_INFO_LOW,
 		      buttons);
-	  	
+
 	      }, 2000);
 
 	      Prefs.setBoolPref("firstrun",false);

--- a/content/pageInfo.js
+++ b/content/pageInfo.js
@@ -6,29 +6,29 @@
     const panel = document.createElement("vbox");
     panel.setAttribute("id","ccffextPanel");
     document.getElementById("mainDeck").appendChild(panel);
-    
+
     // Horizontal box at the top
     const topLine = document.createElement("hbox");
     panel.appendChild(topLine);
-    
+
     // Label showing the number of licensed objects
     const numberLabel = document.createElement("label");
     numberLabel.setAttribute("flex","1");
     topLine.appendChild(numberLabel);
-    
+
     // Checkbox indicating whether to highlight licensed objects on page or not
     const highlightBox = document.createElement("checkbox");
     highlightBox.setAttribute("id","ccffext-highlight");
     highlightBox.setAttribute("label",ccffext.l10n.get("checkbox.highlight.label"));
     highlightBox.setAttribute("checked","true"); // By default, the objects are highlighted
     // topLine.appendChild(highlightBox);
-    
+
     // List of licensed objects
     const list = document.createElement("vbox");
     list.setAttribute("id","ccffext-objects");
     list.setAttribute("flex","1");
     panel.appendChild(list);
-    
+
     // List of added items
     var items = [];
 }
@@ -38,13 +38,13 @@
  **/
 {
     const tab = document.createElement("radio");
-    
+
     with (tab)
     {
 	setAttribute("id","ccffext-tab");
 	setAttribute("label",ccffext.l10n.get("tab.title.label"));
 	setAttribute("accesskey",ccffext.l10n.get("tab.title.key"));
-	
+
 	addEventListener("command",function() {
 
 	    const doc = window.opener.content.document;
@@ -54,29 +54,29 @@
 	    // Update the label showing the number of objects
 	    numberLabel.setAttribute("value",
 				     ccffext.l10n.get("label.number.label",objects.length));
-	    
+
 	    // Remove all previously added items from the list
 	    for (let i = 0; i < items.length; ++i)
 	    {
 		list.removeChild(items[i]);
 	    }
-	    
+
 	    items = [];
-	    
+
 	    var convertStrings = function(strings,part)
 	    {
 		var converted = [];
-		
+
 		for (let i = 0; i < strings.length; ++i)
 		{
 		    let name = strings[i].toLowerCase().replace(/[^a-z]/g,"");
 		    converted.push(ccffext.l10n.get("object.license." + part + "." + name + ".label"));
 		}
-		
+
 		var line = converted.join(", ");
 		return line.substring(0,1).toUpperCase() + line.substring(1);
 	    }
-	    
+
 	    // Add new items to the list
 	    for (let i = 0; i < objects.length; ++i)
 	    {
@@ -84,27 +84,27 @@
 		item.setAttribute("class","item");
 		items.push(item);
 		list.appendChild(item);
-		
+
 		const leftPanel = document.createElement("vbox");
 		leftPanel.setAttribute("class","primary");
 		leftPanel.setAttribute("flex","1");
 		item.appendChild(leftPanel);
-		
+
 		const title = document.createElement("label");
 		title.setAttribute("class","title");
 		title.setAttribute("value",ccffext.objects.getDisplayTitle(
 		    doc.location.href, objects[i]));
 		leftPanel.appendChild(title);
-		
+
 		const sourceLine = document.createElement("hbox");
 		sourceLine.setAttribute("class","line primary");
 		leftPanel.appendChild(sourceLine);
-		
+
 		const sourceTitle = document.createElement("label");
 		sourceTitle.setAttribute("class","line-title");
 		sourceTitle.setAttribute("value",ccffext.l10n.get("object.source.title.label"));
 		sourceLine.appendChild(sourceTitle);
-		
+
 		var source = ccffext.objects.getSource(
 		    doc.location.href, objects[i]);
 		const sourceValue = document.createElement("label");
@@ -115,7 +115,7 @@
 		    window.open(this.getAttribute("uri"));
 		},true);
 		sourceLine.appendChild(sourceValue);
-		
+
 		var type = ccffext.objects.getType(
 		    doc.location.href, objects[i]);
 		if ("undefined" != typeof type)
@@ -123,19 +123,19 @@
 		    const typeLine = document.createElement("hbox");
 		    typeLine.setAttribute("class","line");
 		    leftPanel.appendChild(typeLine);
-		    
+
 		    const typeTitle = document.createElement("label");
 		    typeTitle.setAttribute("class","line-title");
 		    typeTitle.setAttribute("value",ccffext.l10n.get("object.type.title.label"));
 		    typeLine.appendChild(typeTitle);
-		    
+
 		    const typeValue = document.createElement("label");
 		    var line = ccffext.l10n.get("object.type."
 						+ type.toLowerCase().replace(/[^a-z]/g,"") + ".label");
 		    typeValue.setAttribute("value",line.substring(0,1).toUpperCase() + line.substring(1));
 		    typeLine.appendChild(typeValue);
 		}
-		
+
 		var author = ccffext.objects.getAuthor(
 		    doc.location.href, objects[i]);
 		var authorUri = ccffext.objects.getAuthorUri(
@@ -145,16 +145,16 @@
 		    const authorLine = document.createElement("hbox");
 		    authorLine.setAttribute("class","line");
 		    leftPanel.appendChild(authorLine);
-		    
+
 		    const authorTitle = document.createElement("label");
 		    authorTitle.setAttribute("class","line-title");
 		    authorTitle.setAttribute("value",ccffext.l10n.get("object.author.title.label"));
 		    authorLine.appendChild(authorTitle);
-		    
+
 		    const authorValue = document.createElement("label");
 		    authorValue.setAttribute("value",author);
 		    authorLine.appendChild(authorValue);
-		    
+
 		    if ("undefined" != authorUri)
 		    {
 			authorValue.setAttribute("class","anchor");
@@ -164,23 +164,23 @@
 			},true);
 		    }
 		}
-		
+
 		const licenseLine = document.createElement("hbox");
 		licenseLine.setAttribute("class","line primary");
 		leftPanel.appendChild(licenseLine);
-		
+
 		const licenseTitle = document.createElement("label");
 		licenseTitle.setAttribute("class","line-title");
 		licenseTitle.setAttribute("value",ccffext.l10n.get("object.license.title.label"));
 		licenseLine.appendChild(licenseTitle);
-		
+
 		var licenseValue = document.createElement("label");
 		licenseValue.setAttribute("class","anchor");
 		licenseValue.addEventListener("click",function(event) {
 		    window.open(this.getAttribute("uri"));
 		},true);
 		licenseLine.appendChild(licenseValue);
-				
+
 		const attribLine = document.createElement("vbox");
 		attribLine.setAttribute("class","line primary");
 		leftPanel.appendChild(attribLine);
@@ -194,7 +194,7 @@
 		attribTitle.setAttribute("value",
 					 ccffext.l10n.get("object.attribution.label"));
 		attribTitleContainer.appendChild(attribTitle);
-		
+
 		const attribFormat = document.createElement("menulist");
 		const attribFormatMenu = document.createElement("menupopup");
 		const attribFormatHtml = document.createElement("menuitem");
@@ -215,7 +215,7 @@
 		attribContainer.setAttribute("class", "indented");
 		attribContainer.setAttribute("align", "start");
 		attribLine.appendChild(attribContainer);
-		
+
 		var attribText = document.createElement("textbox");
 		attribText.setAttribute("flex","1");
 		attribText.setAttribute("multiline", "true");
@@ -230,25 +230,25 @@
 			switch (e.currentTarget.selectedItem.value) {
 			case "html":
 			    textbox.setAttribute(
-				"value", 
+				"value",
 				ccffext.objects.getAttributionHtml(
 				    doc_uri, object));
 			    break;
 			case "text":
 			    textbox.setAttribute(
-				"value", 
+				"value",
 				ccffext.objects.getAttributionText(
 				    doc_uri, object));
 			    break;
 			}
 		    }
-		  
+
 		    return onSelect;
 		}
 
 		attribFormat.addEventListener(
-		    "select", 
-		    formatListener(attribText, doc.location.href, objects[i]), 
+		    "select",
+		    formatListener(attribText, doc.location.href, objects[i]),
 		    true);
 
 		licenses.getLicenseInfo(
@@ -258,9 +258,9 @@
 			args[0].setAttribute("value",license.name);
 			args[0].setAttribute("uri",license.uri);
 			args[1].setAttribute(
-			    "value", 
+			    "value",
 			    ccffext.objects.getAttributionHtml(args[2], args[3]));
-		    }, [licenseValue, attribText, doc.location.href, 
+		    }, [licenseValue, attribText, doc.location.href,
 			objects[i]]);
 
 		const attribCopyButton = document.createElement("button");
@@ -278,14 +278,14 @@
 			}
 			return clickHandler;
 		    }(attribText), true);
-		
+
 		attribContainer.appendChild(attribCopyButton);
 	    }
-	    
+
 	    // Eventually switch to the tab
 	    showTab('ccffext'); // Activates a panel with the "ccffextPanel" id
 	},true);
     }
-    
+
     document.getElementById("viewGroup").appendChild(tab);
 }

--- a/content/pageInfo.xul
+++ b/content/pageInfo.xul
@@ -6,7 +6,7 @@
 <!-- Setup UI augmentations -->
 <overlay xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
 	<!-- Bootstrap scripts -->
-	<script type="text/javascript" 
+	<script type="text/javascript"
 		src="resource://ccffext/bootstrap.js"></script>
 
 	<!-- Control the "Page Info" dialog behavior -->

--- a/module/bootstrap.js
+++ b/module/bootstrap.js
@@ -6,6 +6,6 @@
  */
 {
     Components.utils.import("resource://ccffext/rdfa.js");
-    Components.utils.import("resource://ccffext/ccffext.js"); 
+    Components.utils.import("resource://ccffext/ccffext.js");
     Components.utils.import("resource://ccffext/license.js");
 }

--- a/module/ccffext.js
+++ b/module/ccffext.js
@@ -13,9 +13,9 @@ Components.utils.import("resource://ccffext/rdfa.js");
 var ccffext =
 {
     /**
-     * An extension of the "Array" object's prototype. 
+     * An extension of the "Array" object's prototype.
      * Inspired by Shamasis Bhattacharya's code
-     * 
+     *
      * @return array An array of unique items
      * @see http://www.shamasis.net/2009/09/fast-algorithm-to-find-unique-items-in-javascript-array/
      */
@@ -27,12 +27,12 @@ var ccffext =
 	{
 	    object[in_array[i]] = in_array[i];
 	}
-	
+
 	for(let i in object)
 	{
 	    result.push(object[i]);
 	}
-	
+
 	return result;
     },
 
@@ -78,7 +78,7 @@ var ccffext =
 		    ccffext.l10n.getPlural = PluralForm
 			.makeGetter(ccffext.l10n.bundle.GetStringFromName("l10n.plural.rule"))[0];
 		}
-		
+
 		// Find appropriate plural form, substitute the placeholder
 		return ccffext.l10n.getPlural(
 		    number,
@@ -134,7 +134,7 @@ var ccffext =
 	{
 	    ccffext.cache.values[key] = object;
 	},
-	
+
 	putDocument : function(location,last_modified,object)
 	{
 	    ccffext.cache.values[location] = object;
@@ -151,7 +151,7 @@ var ccffext =
 	    return ccffext.cache.values[key];
 	}
     },
-    
+
     /**
      * Licensed objects (RDFa subjects) methods
      **/
@@ -173,16 +173,16 @@ var ccffext =
 	 */
 	getLicensedSubjects : function(doc_uri)
 	{
-	    
+
 	    // get the set of statements extracted from the location
 	    let statements = ccffext.cache.get(doc_uri).statements;
 	    // get an array of subjects which have a license predicate
-	    var subjects = [s.subject for each (s in statements) 
+	    var subjects = [s.subject for each (s in statements)
 			    if (ccffext.objects.predicates.indexOf(s.predicate.uri) > -1)];
 
 	    return ccffext.unique(subjects);
 	},
-	
+
 	/**
 	 * Returns an array of "predicate-object" pairs for the specified subject
 	 *
@@ -193,7 +193,7 @@ var ccffext =
 	getPredObjPairs : function(doc_uri,subject)
 	{
 	    var pairs = [];
-	    
+
 	    let statements = ccffext.cache.get(doc_uri).statements;
 	    for (let i = 0; i < statements.length; ++i)
 	    {
@@ -202,13 +202,13 @@ var ccffext =
 		    pairs.push([statements[i].predicate,statements[i].object]);
 		}
 	    }
-	    
+
 	    return pairs;
 	},
 
 	/**
 	 * Return the first object for the given subject and predicate.
-	 * 
+	 *
 	 * @param doc_uri The URI of the document containing the assertions.
 	 * @param subject The subject object to match.
 	 * @predicates array Predicates to search for, in order of preference.
@@ -218,15 +218,15 @@ var ccffext =
 	getValue : function(doc_uri, subject, predicates) {
 
 	    for each (let p in predicates) {
-		for (let i = 0, 
-		     pairs = ccffext.objects.getPredObjPairs(doc_uri,subject); 
+		for (let i = 0,
+		     pairs = ccffext.objects.getPredObjPairs(doc_uri,subject);
 		     i < pairs.length; ++i) {
 		    if (pairs[i][0].uri == p) {
 			return pairs[i][1];
 		    }
 		}
 	    }
-	    
+
 	    return undefined;
 
 	}, // getValue
@@ -242,13 +242,13 @@ var ccffext =
 
 	    XH.transform(document.getElementsByTagName("body")[0]);
 	    XH.transform(document.getElementsByTagName("head")[0]);
-	    
+
 	    RDFA.reset();
 	    RDFA.parse(document);
-	    
+
 	    ccffext.cache.putDocument(location, document.lastModified, RDFA.triplestore);
 
-	    // Apply any site-specific hacks 
+	    // Apply any site-specific hacks
 	    // -- these hacks are applied for high value adopters, who
 	    // -- for whatever reason have adopted, ahem, imperfectly.
 	    Components.utils.import("resource://ccffext/hacks/hacks.js");
@@ -258,17 +258,17 @@ var ccffext =
 
 	    // see if the document contains license information
 	    ccffext.objects.callbackify(
-		document, 
+		document,
 		function (doc, objects) {
 
 		    Components.utils.import("resource://ccffext/license.js");
 
-		    // this document has licensed objects; 
+		    // this document has licensed objects;
 		    // get the list of uncached licenses to retrieve
 		    // and pass each to the license loader
 		    [l.uri for each (l in ccffext.unique([
 			    ccffext.objects.getLicense(location, subject)
-			    for each (subject in objects) 
+			    for each (subject in objects)
 			if ("undefined" !== typeof subject)]) )
 			if ("undefined" !== typeof l &&
 			    !ccffext.cache.contains(l.uri))]
@@ -278,7 +278,7 @@ var ccffext =
 		});
 
 	},
-	
+
 	/**
 	 * Checks if the cache contains the information for a document, calling a callback if not. Then calls a callback
 	 * if the document has any licensed objects
@@ -286,20 +286,20 @@ var ccffext =
 	callbackify : function(document,callbackHas,callbackNotCached)
 	{
 	    const location = document.location.href;
-	    
+
 	    // For all pages, except for system ones like "about:blank", "about:config" and so on
 	    if (! location.match(/^about\:/i))
 	    {
-		if (! ccffext.cache.containsDocument(document) && 
+		if (! ccffext.cache.containsDocument(document) &&
 		    "function" == typeof callbackNotCached)
 		{
 		    callbackNotCached(document);
 		}
-		
+
 		if (ccffext.cache.containsDocument(document))
 		{
 		    const objects = ccffext.objects.getLicensedSubjects(location);
-		    
+
 		    if (0 < objects.length && "function" == typeof callbackHas)
 		    {
 			callbackHas(document,objects);
@@ -307,7 +307,7 @@ var ccffext =
 		}
 	    }
 	},
-	
+
 	/**
 	 * Returns a title for a licensed subject.
 	 *
@@ -321,7 +321,7 @@ var ccffext =
 		["http://purl.org/dc/terms/title",
 		 "http://purl.org/dc/elements/1.1/title"]);
 	},
-	
+
 	/**
 	 * Returns the display title for a licensed subject. If no
 	 * title is available, and the subject URI is the same as the
@@ -335,7 +335,7 @@ var ccffext =
 	    var title = ccffext.objects.getTitle(doc_uri, subject);
 
 	    if (typeof title != "undefined") return title;
-	    
+
 	    return doc_uri == subject.uri
 		? ccffext.l10n.get("object.title.current-page.label")
 		: subject.uri;
@@ -350,11 +350,11 @@ var ccffext =
 	getType : function(doc_uri,object)
 	{
 	    var type = ccffext.objects.getValue(
-		doc_uri, object, 
+		doc_uri, object,
 		["http://purl.org/dc/terms/type",
 		 "http://purl.org/dc/elements/1.1/type"]);
 
-	    if ("undefined" != typeof type) 
+	    if ("undefined" != typeof type)
 		return type.uri.replace("http://purl.org/dc/dcmitype/","");
 
 	    return undefined;
@@ -369,10 +369,10 @@ var ccffext =
 	getAuthor : function(doc_uri,object)
 	{
 	    return ccffext.objects.getValue(
-		doc_uri, object, 
+		doc_uri, object,
 		["http://creativecommons.org/ns#attributionName"]);
 	},
-	
+
 	/**
 	 * Returns an URI for an author for a licensed object
 	 *
@@ -382,10 +382,10 @@ var ccffext =
 	getAuthorUri : function(doc_uri,object)
 	{
 	    return ccffext.objects.getValue(
-		doc_uri, object, 
+		doc_uri, object,
 		["http://creativecommons.org/ns#attributionURL"]);
 	},
-	
+
 	/**
 	 * Returns a source for a licensed object.
 	 *
@@ -418,7 +418,7 @@ var ccffext =
 
 	    attrib_name = ccffext.objects.getAuthor(doc_uri, object);
 	    attrib_url = ccffext.objects.getAuthorUri(doc_uri, object);
-	    
+
 	    // create the pieces for the attribution HTML
 	    attrib_pieces = new Array();
 	    attrib_ns = new Object();
@@ -433,18 +433,18 @@ var ccffext =
 
 		// no attribution metadata available
 		attrib_pieces.push(
-		    'Work found at <a href="' + object.uri + '">' + 
-			object.uri + '</a> ');	
+		    'Work found at <a href="' + object.uri + '">' +
+			object.uri + '</a> ');
 	    }
 
 	    // -- attrib name/URL
-	    if ("undefined" != typeof attrib_name || 
+	    if ("undefined" != typeof attrib_name ||
 		"undefined" != typeof attrib_url) {
 		// we have at least one of the name + URL
 		if ("undefined" == typeof attrib_url) {
 		    // no attribution URL
 		    attrib_pieces.push(
-			'<span property="cc:attributionName">' + 
+			'<span property="cc:attributionName">' +
 			    attrib_name + '</span>'
 		    );
 
@@ -454,18 +454,18 @@ var ccffext =
 			// w/o attrib_name we include the URL as the link text
 			// but do not annotate it as the attribution name
 			attrib_pieces.push(
-			    '<a rel="cc:attributionURL" ' + 
-				'href="' + attrib_url.uri + '">' + 
+			    '<a rel="cc:attributionURL" ' +
+				'href="' + attrib_url.uri + '">' +
 				attrib_url.uri +
 				'</a>'
 			);
-			
+
 		    } else {
 
 			attrib_pieces.push(
-			    '<a rel="cc:attributionURL" ' + 
-				'property="cc:attributionName" ' + 
-				'href="' + attrib_url.uri + '">' + 
+			    '<a rel="cc:attributionURL" ' +
+				'property="cc:attributionName" ' +
+				'href="' + attrib_url.uri + '">' +
 				attrib_name + '</a>'
 			);
 		    }
@@ -479,7 +479,7 @@ var ccffext =
 	    // -- license
 	    attrib_pieces.push(
 		'<a rel="license" href="' + license.uri + '">' +
-		    (license.identifier ? license.identifier : license.name) + 
+		    (license.identifier ? license.identifier : license.name) +
 		    '</a>');
 
 	    // assemble the final HTML from the pieces
@@ -509,7 +509,7 @@ var ccffext =
 
 	    attrib_name = ccffext.objects.getAuthor(doc_uri, object);
 	    attrib_url = ccffext.objects.getAuthorUri(doc_uri, object);
-	    
+
 	    // create the pieces for the attribution HTML
 	    attrib_pieces = new Array();
 
@@ -521,10 +521,10 @@ var ccffext =
 		// no attribution metadata available
 		attrib_pieces.push('Work found at ' + object.uri);
 
-	    } 
+	    }
 
 	    // -- attrib name/URL
-	    if ("undefined" != typeof attrib_name || 
+	    if ("undefined" != typeof attrib_name ||
 		"undefined" != typeof attrib_url) {
 		// we have at least one of the name + URL
 		if ("undefined" == typeof attrib_url) {
@@ -537,7 +537,7 @@ var ccffext =
 			// w/o attrib_name we include the URL as the link text
 			// but do not annotate it as the attribution name
 			attrib_pieces.push("(" + attrib_url.uri + ")");
-			
+
 		    } else {
 
 			attrib_pieces.push(
@@ -568,7 +568,7 @@ var ccffext =
 
 	},
     },
-        
+
     /**
      * Utility function that writes a message to the JavaScript console
      *

--- a/module/hacks/hacks.js
+++ b/module/hacks/hacks.js
@@ -17,12 +17,12 @@ var ccffext_site_hacks = new function Hacks() {
     };
 
     /**
-     * 
+     *
      * Evaluate a series of xpath expressions against a document,
      * returning the string value of the first that has a match.
-     * 
+     *
      * exprs is an Array of xpath expressions
-     * 
+     *
      **/
     this.evaluateXpath = function (document, exprs) {
 
@@ -70,7 +70,7 @@ ccffext_site_hacks.register(
 	if ("undefined" != typeof authorUri) {
 	    triples.add(new RDFSymbol(location),
 			new RDFSymbol("http://creativecommons.org/ns#attributionURL"),
-			new RDFSymbol(Util.uri.join(authorUri, location)), 
+			new RDFSymbol(Util.uri.join(authorUri, location)),
 			'RDFa');
 
 	}
@@ -83,7 +83,7 @@ ccffext_site_hacks.register(
 
 	// import the RDFa library
 	Components.utils.import("resource://ccffext/rdfa.js");
-	
+
 	// Wikipedias are licensed CC BY-SA 3.0 Unported
 	// remove any license triples that may have crept in
 	// (enwp uses rel="license", others do not)
@@ -95,6 +95,6 @@ ccffext_site_hacks.register(
 	// add the license triple
 	triples.add(new RDFSymbol(location),
 		    new RDFSymbol("http://www.w3.org/1999/xhtml/vocab#license"),
-		    new RDFSymbol("http://creativecommons.org/licenses/by-sa/3.0/"), 
-		    'RDFa');	
+		    new RDFSymbol("http://creativecommons.org/licenses/by-sa/3.0/"),
+		    'RDFa');
     }); // wikipedia

--- a/module/license.js
+++ b/module/license.js
@@ -16,17 +16,17 @@ var licenses = new function Licenses() {
 	browser.webNavigation.allowMetaRedirects = true;
 	browser.webNavigation.allowPlugins = false;
 	browser.webNavigation.allowSubframes = false;
-	
+
 	// attach the event listener which will handle parsing licenses
 	browser.addEventListener(
 	    "DOMContentLoaded", onDomLoaded, true);
-	
+
 	// store a reference to the browser
 	license_frame = browser;
-	
+
 	// reset the internal state flag
 	working = false;
-				
+
     }; // init
 
     this.load = function (license_uri, callback) {
@@ -66,7 +66,7 @@ var licenses = new function Licenses() {
      * @param license_uri The URI of the license to load
      * @param callback Callback when the license details have been retrieved;
      * @param cb_args An array to be passed into the callback
-     * 
+     *
      *        This is called with the signature (license, cb_args).
      **/
     this.getLicenseInfo = function(license_uri, callback, cb_args) {
@@ -78,7 +78,7 @@ var licenses = new function Licenses() {
 	    code: undefined,
 	    color : undefined
 	};
-	    
+
 	license.uri = license.name = that.normalizeLicenseUri(license_uri);
 
 	if (ccffext.cache.contains(license.uri)) {
@@ -90,7 +90,7 @@ var licenses = new function Licenses() {
 	    if ("undefined" != typeof callback) {
 		callback (license, cb_args);
 	    }
-	} else 
+	} else
 
 	// retrieve the license document to introspect for RDFa
 	if ("undefined" != typeof license_frame) {
@@ -105,14 +105,14 @@ var licenses = new function Licenses() {
 		      });
 
 	} // if a license browser is available
-	else 
+	else
 
-	    // make sure the call back happens, 
+	    // make sure the call back happens,
 	    // even if we can't load the license
 	    if ("undefined" != typeof callback) {
 		callback (license, cb_args);
 	    }
-	    
+
 	return license;
 
     }; // getLicenseInfo
@@ -120,14 +120,14 @@ var licenses = new function Licenses() {
     function populateLicenseObject(license) {
 
 	license.name = ccffext.objects.getValue(
-	    license.uri, {'uri':license.uri}, 
+	    license.uri, {'uri':license.uri},
 	    ["http://purl.org/dc/terms/title",
 	     "http://purl.org/dc/elements/1.1/title"]);
-			    
-	if ("object" == typeof license.name) 
+
+	if ("object" == typeof license.name)
 	    license.name = license.name.toString();
-		
-	if ("string" == typeof license.name) 
+
+	if ("string" == typeof license.name)
 	    license.name = license.name.trim();
 
 	license.identifier = ccffext.objects.getValue(
@@ -135,10 +135,10 @@ var licenses = new function Licenses() {
 	    ["http://purl.org/dc/terms/identifier",
 	     "http://purl.org/dc/elements/1.1/identifier"]);
 
-	if ("object" == typeof license.identifier) 
+	if ("object" == typeof license.identifier)
 	    license.identifier = license.identifier.toString();
-		
-	if ("string" == typeof license.identifier) 
+
+	if ("string" == typeof license.identifier)
 	    license.identifier = license.identifier.trim();
 
 	if (license.uri.indexOf("http://creativecommons.org/") == 0) {
@@ -159,7 +159,7 @@ var licenses = new function Licenses() {
 	case "publicdomain":
 	    license.color = "green";
 	    break;
-	    
+
 	case "by-nc":
 	case "by-nd":
 	case "by-nc-nd":
@@ -168,17 +168,17 @@ var licenses = new function Licenses() {
 	case "nc-sampling+":
 	    license.color = "yellow";
 	    break;
-	    
+
 	case "sampling":
 	case "devnations":
 	    license.color = "red";
 	    break;
 	}; // switch on license code
-	
+
     }; // populateLicenseObject
 
     function onDomLoaded (e) {
-	
+
 	var doc = e.originalTarget;
 	var url = doc.location.href;
 
@@ -187,7 +187,7 @@ var licenses = new function Licenses() {
 
 	// reset flags
 	working = false;
-	
+
 	// see if there's anything else to process once we're done
 	timer.initWithCallback(
 	    that,
@@ -224,7 +224,7 @@ var licenses = new function Licenses() {
 	    license_frame.webNavigation.loadURI(
 		_current_license,
 		Components.interfaces.nsIWebNavigation, null, null, null);
-	}	   
+	}
 
     }; // check_queue
 

--- a/module/rdfa.js
+++ b/module/rdfa.js
@@ -7,7 +7,7 @@ var EXPORTED_SYMBOLS = ["RDFA","XH", "RDFSymbol", "RDFLiteral", "Util"];
  *  Jeni Tennison - jeni@jenitennison.com
  *
  *  W3C Open Source License
- * 
+ *
  * includes the AJAR (Tabulator) stuff
  */
 //
@@ -70,13 +70,13 @@ Util.uri.join = function (given, base) {
 
     if (given.indexOf('/') == 0)    // starts with / but not //
     return base.slice(0, baseSingle) + given
-    
+
     var path = base.slice(baseSingle)
     var lastSlash = path.lastIndexOf("/")
     if (lastSlash <0) return baseScheme + given
     if ((lastSlash >=0) && (lastSlash < (path.length-1)))
     path = path.slice(0, lastSlash+1) // Chop trailing filename from base
-    
+
     path = path + given
     while (path.match(/[^\/]*\/\.\.\//)) // must apply to result of prev
     path = path.replace( /[^\/]*\/\.\.\//, '') // ECMAscript spec 7.8.5
@@ -127,7 +127,7 @@ Util.uri.docpart = function (uri) {
     var i = uri.indexOf("#")
     if (i < 0) return uri
     return uri.slice(0,i)
-} 
+}
 
 /** return the protocol of a uri **/
 Util.uri.protocol = function (uri) {
@@ -160,7 +160,7 @@ function makeTerm(val) {
     if (typeof val == 'object') return val;
     if (typeof val == 'string') return new RDFLiteral(val);
     if (typeof val == 'number') return new RDFLiteral(val); // @@ differet types
-    if (typeof val == 'boolean') return new RDFLiteral(val?"1":"0", undefined, 
+    if (typeof val == 'boolean') return new RDFLiteral(val?"1":"0", undefined,
                                                 RDFSymbol.prototype.XSDboolean);
     if (typeof val == 'undefined') return undefined;
     alert("Can't make term from " + val + " of type " + typeof val);
@@ -188,7 +188,7 @@ function RDFSymbol(uri) {
     this.uri = uri
     return this
 }
-    
+
 RDFSymbol.prototype.termType = 'symbol'
 RDFSymbol.prototype.toString = toNT
 RDFSymbol.prototype.toNT = toNT
@@ -221,7 +221,7 @@ RDFBlankNode.prototype.termType = 'bnode'
 RDFBlankNode.prototype.toNT = function() {
     return NTAnonymousNodePrefix + this.id
 }
-RDFBlankNode.prototype.toString = RDFBlankNode.prototype.toNT  
+RDFBlankNode.prototype.toString = RDFBlankNode.prototype.toNT
 
 //  Literal
 
@@ -257,8 +257,8 @@ function RDFLiteral_toNT() {
 function RDFLiteralToString() {
     return this.value
 }
-    
-RDFLiteral.prototype.toString = RDFLiteralToString   
+
+RDFLiteral.prototype.toString = RDFLiteralToString
 RDFLiteral.prototype.toNT = RDFLiteral_toNT
 
 function RDFCollection() {
@@ -272,7 +272,7 @@ RDFCollection.prototype.termType = 'collection'
 RDFCollection.prototype.toNT = function() {
     return NTAnonymousNodePrefix + this.id
 }
-RDFCollection.prototype.toString = RDFCollection.prototype.toNT 
+RDFCollection.prototype.toString = RDFCollection.prototype.toNT
 
 RDFCollection.prototype.append = function (el) {
     this.elements.push(el)
@@ -283,7 +283,7 @@ RDFCollection.prototype.unshift=function(el){
 RDFCollection.prototype.shift=function(){
     return this.elements.shift();
 }
-        
+
 RDFCollection.prototype.close = function () {
     this.closed = true
 }
@@ -314,7 +314,7 @@ function RDFStatement(subject, predicate, object, why) {
 
 RDFStatement.prototype.toNT = RDFStatement_toNT
 RDFStatement.prototype.toString = RDFStatement_toNT
-    
+
 
 //  Formula
 //
@@ -337,7 +337,7 @@ function RDFFormula_toNT() {
 //RDFQueryFormula.termType = 'queryFormula'
 RDFFormula.prototype.termType = 'formula'
 RDFFormula.prototype.toNT = RDFFormula_toNT
-RDFFormula.prototype.toString = RDFFormula_toNT   
+RDFFormula.prototype.toString = RDFFormula_toNT
 
 RDFFormula.prototype.add = function(subj, pred, obj, why) {
     this.statements.push(new RDFStatement(subj, pred, obj, why))
@@ -402,7 +402,7 @@ RDFFormula.prototype.registerFormula = function(accesskey){
 ** a common special base URI for variables.
 */
 
-var RDFVariableBase = "varid:"; // We deem variabe x to be the symbol varid:x 
+var RDFVariableBase = "varid:"; // We deem variabe x to be the symbol varid:x
 
 function RDFVariable(rel) {
     this.uri = URIjoin(rel, RDFVariableBase);
@@ -426,7 +426,7 @@ RDFFormula.prototype.variable = function(name) {
 RDFVariable.prototype.hashString = RDFVariable.prototype.toNT;
 
 
-// The namespace function generator 
+// The namespace function generator
 
 function Namespace(nsuri) {
     return function(ln) { return new RDFSymbol(nsuri+(ln===undefined?'':ln)) }
@@ -504,7 +504,7 @@ RDFCollection.prototype.sameTerm = RDFBlankNode.prototype.sameTerm
 //
 // When we smush nodes we take the lowest value. This is not
 // arbitrary: we want the value actually used to be the literal
-// (or list or formula). 
+// (or list or formula).
 
 RDFLiteral.prototype.classOrder = 1
 // RDFList.prototype.classOrder = 2
@@ -523,7 +523,7 @@ RDFLiteral.prototype.compareTerm = function(other) {
     if (this.value < other.value) return -1
     if (this.value > other.value) return +1
     return 0
-} 
+}
 
 RDFSymbol.prototype.compareTerm = function(other) {
     if (this.classOrder < other.classOrder) return -1
@@ -531,7 +531,7 @@ RDFSymbol.prototype.compareTerm = function(other) {
     if (this.uri < other.uri) return -1
     if (this.uri > other.uri) return +1
     return 0
-} 
+}
 
 RDFBlankNode.prototype.compareTerm = function(other) {
     if (this.classOrder < other.classOrder) return -1
@@ -539,7 +539,7 @@ RDFBlankNode.prototype.compareTerm = function(other) {
     if (this.id < other.id) return -1
     if (this.id > other.id) return +1
     return 0
-} 
+}
 
 RDFCollection.prototype.compareTerm = RDFBlankNode.prototype.compareTerm
 
@@ -565,7 +565,7 @@ RDFFormula.prototype.each = function(s,p,o,w) {
 RDFFormula.prototype.any = function(s,p,o,w) {
     var st = this.anyStatementMatching(s,p,o,w)
     if (typeof st == 'undefined') return undefined;
-    
+
     if (typeof s == 'undefined') return st.subject;
     if (typeof p == 'undefined') return st.predicate;
     if (typeof o == 'undefined') return st.object;
@@ -582,7 +582,7 @@ RDFFormula.prototype.the = function(s,p,o,w) {
 RDFFormula.prototype.whether = function(s,p,o,w) {
     return this.statementsMatching(s,p,o,w).length;
 }
- 
+
 // Not a method. For use in sorts
 function RDFComparePredicateObject(self, other) {
     var x = self.predicate.compareTerm(other.predicate)
@@ -602,7 +602,7 @@ function RDFComparePredicateSubject(self, other) {
 // This file provides  RDFIndexedFormula a formula (set of triples) which
 // indexed by predicate, subject and object.
 //
-// It "smushes"  (merges into a single node) things which are identical 
+// It "smushes"  (merges into a single node) things which are identical
 // according to owl:sameAs or an owl:InverseFunctionalProperty
 // or an owl:FunctionalProperty
 //
@@ -610,7 +610,7 @@ function RDFComparePredicateSubject(self, other) {
 //
 //  2005-10 Written Tim Berners-Lee
 //
-// 
+//
 
 /*jsl:option explicit*/ // Turn on JavaScriptLint variable declaration checking
 
@@ -659,7 +659,7 @@ function RDFIndexedFormula(features) {
 //    this.features = features
 
     // Callbackify?
-    
+
     function handleRDFType(formula, subj, pred, obj, why) {
         if (typeof formula.typeCallback != 'undefined')
             formula.typeCallback(formula, obj, why);
@@ -718,7 +718,7 @@ function RDFIndexedFormula(features) {
         formula.equate(o1, obj);
         return true ;
     } //handle_FP
-    
+
 } /* end RDFIndexedFormula */
 
 var RDFPlainFormula = function() { return RDFIndexedFormula([]); } // No features
@@ -746,7 +746,7 @@ We replace the bigger with the smaller.
 */
 RDFIndexedFormula.prototype.equate = function(u1, u2) {
     //tabulator.log.info("Equating "+u1+" and "+u2)
-    
+
     var d = u1.compareTerm(u2);
     if (!d) return true; // No information in {a = a}
     var big, small;
@@ -776,7 +776,7 @@ RDFIndexedFormula.prototype.replaceWith = function(big, small) {
 
     // If we allow equating predicates we must index them.
     toBeFixed = this.statementsMatching(undefined, big, undefined);
-    
+
     for (i = 0; i < toBeFixed.length; i++) {
     toBeFixed[i].predicate = small;
     hash = small.hashString();
@@ -785,7 +785,7 @@ RDFIndexedFormula.prototype.replaceWith = function(big, small) {
     this.predicateIndex[hash].push(toBeFixed[i]);
     }
     delete this.predicateIndex[big.hashString()];
-    
+
     toBeFixed = this.statementsMatching(undefined, undefined, big);
     for (i=0; i < toBeFixed.length; i++) {
         //  RDFArrayRemove(this.objectIndex[big], st)
@@ -796,7 +796,7 @@ RDFIndexedFormula.prototype.replaceWith = function(big, small) {
         this.objectIndex[hash].push(toBeFixed[i]);
     }
     delete this.objectIndex[big.hashString()];
-    
+
     this.redirection[big.hashString()] = small;
     if (big.uri) {
     if (typeof (this.aliases[small.hashString()]) == 'undefined')
@@ -809,22 +809,22 @@ RDFIndexedFormula.prototype.replaceWith = function(big, small) {
     if (this.sf) {
         this.sf.nowKnownAs(big, small)
     }
-    
+
     }
-    
+
     /* merge actions @@ assumes never > 1 action*/
     var action = this.classAction[big.hashString()];
     if ((typeof action != 'undefined') &&
     (typeof this.classAction[small.hashString()] == 'undefined')) {
         this.classAction[small.hashString()] = action;
     }
-    
+
     action = this.propertyAction[big.hashString()];
     if ((typeof action != 'undefined') &&
     (typeof this.propertyAction[small.hashString()] == 'undefined')) {
         this.propertyAction[small.hashString()] = action;
     }
-    // tabulator.log.debug("Equate done. "+big+" to be known as "+small)    
+    // tabulator.log.debug("Equate done. "+big+" to be known as "+small)
     return true;  // true means the statement does not need to be put in
 };
 
@@ -852,20 +852,20 @@ RDFIndexedFormula.prototype.uris = function(term) {
 // On input parameters, do redirection and convert constants to terms
 // We do not redirect literals
 function RDFMakeTerm(formula,val) {
-    if (typeof val != 'object') {   
+    if (typeof val != 'object') {
     if (typeof val == 'string')
         return new RDFLiteral(val);
         if (typeof val == 'number')
             return new RDFLiteral(val); // @@ differet types
         if (typeof val == 'boolean')
-            return new RDFLiteral(val?"1":"0", undefined, 
+            return new RDFLiteral(val?"1":"0", undefined,
                                             RDFSymbol.prototype.XSDboolean);
     else if (typeof val == 'number')
         return new RDFLiteral(''+val);   // @@ datatypes
     else if (typeof val == 'undefined')
         return undefined;
         else    // @@ add converting of dates and numbers
-        throw "Can't make Term from " + val + " of type " + typeof val; 
+        throw "Can't make Term from " + val + " of type " + typeof val;
     }
     if (typeof formula.redirection == 'undefined') {
         throw 'Internal: No redirection index for formula: '+ formula+', term: '+val;
@@ -890,7 +890,7 @@ RDFIndexedFormula.prototype.add = function(subj, pred, obj, why) {
     pred = RDFMakeTerm(this, pred);
     obj = RDFMakeTerm(this, obj);
     why = RDFMakeTerm(this, why);
-    
+
 
     // Look for strange bug that this is called with no object very occasionally
     // and only when running script in file: space
@@ -899,30 +899,30 @@ RDFIndexedFormula.prototype.add = function(subj, pred, obj, why) {
         +subj+', pred='+pred)
     }
 
-    
-  
+
+
     var hashS = subj.hashString();
     var hashP = pred.hashString();
     var hashO = obj.hashString();
-    
+
     // Check we don't already know it -- esp when working with dbview
     st = this.anyStatementMatching(subj,pred,obj) // @@@@@@@ temp fix <====WATCH OUT!
     if (typeof st != 'undefined') return; // already in store
     //    tabulator.log.debug("\nActions for "+s+" "+p+" "+o+". size="+this.statements.length)
     if (typeof this.predicateCallback != 'undefined')
     this.predicateCallback(this, pred, why);
-    
+
     // Action return true if the statement does not need to be added
     action = this.propertyAction[hashP];
     if (action && action(this, subj, pred, obj, why)) return;
-    
+
     st = new RDFStatement(subj, pred, obj, why);
     if (typeof this.subjectIndex[hashS] =='undefined') this.subjectIndex[hashS] = [];
     this.subjectIndex[hashS].push(st); // Set of things with this as subject
-    
+
     if (typeof this.predicateIndex[hashP] =='undefined') this.predicateIndex[hashP] = [];
     this.predicateIndex[hashP].push(st); // Set of things with this as subject
-    
+
     if (typeof this.objectIndex[hashO] == 'undefined') this.objectIndex[hashO] = [];
     this.objectIndex[hashO].push(st); // Set of things with this as object
     //tabulator.log.debug("ADDING    {"+subj+" "+pred+" "+obj+"} "+why);
@@ -980,7 +980,7 @@ RDFIndexedFormula.prototype.statementsMatching = function(subj,pred,obj,why,just
     //looks for candidate statements matching a given s/p/o
     if (typeof(subj) =='undefined') {
         if (typeof(obj) =='undefined') {
-        if (typeof(pred) == 'undefined') { 
+        if (typeof(pred) == 'undefined') {
         candidates = this.statements; //all wildcards
         } else {
         candidates = this.predicateIndex[pred.hashString()];
@@ -1016,11 +1016,11 @@ RDFIndexedFormula.prototype.statementsMatching = function(subj,pred,obj,why,just
         candidates = oix;
 //      tabulator.log.debug("Wow!  actually used object index instead of subj");
         }
-    
+
         }
         // tabulator.log.debug("Trying only "+candidates.length+" subject statements")
     }
-    
+
     if (typeof candidates == 'undefined') return [];
 //    tabulator.log.debug("Matching {"+s+" "+p+" "+o+"} against "+n+" stmts")
     var st;
@@ -1052,7 +1052,7 @@ RDFIndexedFormula.prototype.remove = function (st) {
     if (typeof this.objectIndex[obj.hashString()] == 'undefined')
         tabulator.log.warn ("statement not in obj index: " +st);
         */
-        
+
     RDFArrayRemove(this.subjectIndex[subj.hashString()], st);
     RDFArrayRemove(this.predicateIndex[pred.hashString()], st);
     RDFArrayRemove(this.objectIndex[obj.hashString()], st);
@@ -1108,12 +1108,12 @@ RDFIndexedFormula.prototype.load = function(url) {
 
 /*  @method: copyTo
     @discription: replace @template with @target and add appropriate triples (no triple removed)
-                  one-direction replication 
-*/ 
+                  one-direction replication
+*/
 RDFIndexedFormula.prototype.copyTo = function(template,target,flags){
     if (!flags) flags=[];
     var statList=this.statementsMatching(template);
-    if (flags.indexOf('two-direction')!=-1) 
+    if (flags.indexOf('two-direction')!=-1)
         statList.concat(this.statementsMatching(undefined,undefined,template));
     for (var i=0;i<statList.length;i++){
         var st=statList[i];
@@ -1130,7 +1130,7 @@ RDFIndexedFormula.prototype.copyTo = function(template,target,flags){
     }
 };
 //for the case when you alter this.value (text modified in userinput.js)
-RDFLiteral.prototype.copy = function(){ 
+RDFLiteral.prototype.copy = function(){
     return new RDFLiteral(this.value,this.lang,this.datatype);
 };
 RDFBlankNode.prototype.copy = function(formula){ //depends on the formula
@@ -1220,7 +1220,7 @@ RDFA.object_copy = function(obj) {
     for (i in obj) {
         the_copy[i] = obj[i];
     }
-    
+
     return the_copy;
 };
 
@@ -1260,7 +1260,7 @@ RDFA.CURIE.parse = function(str, namespaces) {
 };
 
 // 2007-11-25 JT
-// RDFA CURIEorURI abstraction 
+// RDFA CURIEorURI abstraction
 RDFA.CURIEorURI = {};
 
 RDFA.CURIEorURI.parse = function(str, namespaces) {
@@ -1298,12 +1298,12 @@ RDFA.getNodeAttributeValue = function(element, attr) {
 RDFA.setNodeAttributeValue = function(element, attr, value) {
     if (element == null)
         return;
-        
+
     if (element.setAttribute != undefined) {
         element.setAttribute(attr,value);
         return;
     }
-    
+
     if (element.attributes == undefined)
         element.attributes = new Object();
 
@@ -1315,7 +1315,7 @@ RDFA.setNodeAttributeValue = function(element, attr, value) {
 RDFA.each_attr_value = function(attr_values, attr_val_func) {
   if (!attr_values)
     return;
-    
+
   var attr_value_arr = attr_values.split(' ');
   for (var i=0; i<attr_value_arr.length; i++) {
     attr_val_func(attr_value_arr[i]);
@@ -1512,7 +1512,7 @@ RDFA.add_triple = function (base, subject, predicate, object, literal_p, literal
   if (subject == null) {
     return null;
   }
-  
+
   if (predicate == null) {
     // likely a bad CURIE
     return null;
@@ -1528,7 +1528,7 @@ RDFA.add_triple = function (base, subject, predicate, object, literal_p, literal
     if (typeof(object) == 'string')
       object = new RDFSymbol(Util.uri.join(object, base));
   }
-  
+
   return RDFA.triplestore.add(subject, predicate, object, 'RDFa');
 };
 
@@ -1544,11 +1544,11 @@ RDFA.add_namespaces = function(element, namespaces) {
 
     // go through the attributes
     var attributes = element.attributes;
-    
+
     if (!attributes) {
-      return namespaces;      
+      return namespaces;
     }
-    
+
     for (var i=0; i<attributes.length; i++) {
         if (attributes[i].name.substring(0,5) == "xmlns") {
             if (!copied_yet) {
@@ -1557,12 +1557,12 @@ RDFA.add_namespaces = function(element, namespaces) {
             }
 
             if (attributes[i].name.substring(5,6) != ':') {
-              continue;              
+              continue;
             }
 
             var prefix = attributes[i].name.substring(6);
             var uri = attributes[i].value;
-            
+
             namespaces[prefix] = new Namespace(uri);
         }
     }
@@ -1573,7 +1573,7 @@ RDFA.add_namespaces = function(element, namespaces) {
 RDFA.associateElementAndSubject = function(element,subject,namespaces) {
    RDFA.elements_by_subject[subject] = element;
    RDFA.elements.push(element);
-   
+
    element._RDFA_SUBJECT = subject;
    element._RDFA_NAMESPACES = RDFA.object_copy(namespaces);
 };
@@ -1581,7 +1581,7 @@ RDFA.associateElementAndSubject = function(element,subject,namespaces) {
 RDFA.init_hanging = function(subject, base, namespaces) {
   // initialize the hanging structure
   return {'rels' : [], 'revs' : [], 'subject': subject, 'base': base, 'namespaces': RDFA.object_copy(namespaces), 'bnode': new RDFBlankNode()};
-  
+
 }
 // Hanging Chains (Mark's idea)
 RDFA.add_hanging_rel = function(hanging, subject, rel, base, namespaces) {
@@ -1608,17 +1608,17 @@ RDFA.complete_hanging = function(hanging, new_object) {
   // link to the bnode if there's no new object
   if (!new_object)
     new_object = hanging.bnode;
-    
+
   // go through the rels
   for (var i=0; i<hanging.rels.length; i++) {
-    var triple = RDFA.add_triple(hanging.base, hanging.subject, RDFA.CURIE.parse(hanging.rels[i],hanging.namespaces), new_object, false);    
+    var triple = RDFA.add_triple(hanging.base, hanging.subject, RDFA.CURIE.parse(hanging.rels[i],hanging.namespaces), new_object, false);
   }
 
   // go through the revs
   for (var i=0; i<hanging.revs.length; i++) {
-    var triple = RDFA.add_triple(hanging.base, new_object, RDFA.CURIE.parse(hanging.revs[i],hanging.namespaces), hanging.subject, false);    
+    var triple = RDFA.add_triple(hanging.base, new_object, RDFA.CURIE.parse(hanging.revs[i],hanging.namespaces), hanging.subject, false);
   }
-  
+
   return {
     'hanging_result' : null,
     'new_subject' : new_object
@@ -1639,7 +1639,7 @@ RDFA.clear_hanging = function(hanging) {
 RDFA.traverse = function (element, subject, namespaces, lang, base, hanging) {
     // are there namespaces declared
     namespaces = RDFA.add_namespaces(element,namespaces);
-    
+
     // replace the lang if it's non null
     lang = RDFA.getNodeAttributeValue(element, 'xml:lang') || lang;
 
@@ -1658,11 +1658,11 @@ RDFA.traverse = function (element, subject, namespaces, lang, base, hanging) {
 
     // do we explicitly override it?
     var explicit_subject = null;
-    
+
     // @src is a left-hand, explicit subject attribute
     if (attrs['src'])
       explicit_subject = attrs['src'];
-    
+
     // @about is a left-hand, explicit subject attribute that overrides @src
     // 2008-01-18 JT
     // since about="" is legal (and meaningful), changed condition here from
@@ -1680,7 +1680,7 @@ RDFA.traverse = function (element, subject, namespaces, lang, base, hanging) {
     // warn
     if (attrs['instanceof'])
       RDFA.warnings.push("@instanceof has been replaced with @typeof.");
-      
+
     // determine the object
     var explicit_object = null;
 
@@ -1694,19 +1694,19 @@ RDFA.traverse = function (element, subject, namespaces, lang, base, hanging) {
       // @resource is a CURIEorURI
       explicit_object = RDFA.CURIEorURI.parse(attrs['resource'], namespaces);
     }
- 
+
     // if there's only an explicit object but no explicit subject and rel/rev
 	  // that explicit object becomes effectively an explicit subject
 	  if (attrs['rel'] == null && attrs['rev'] == null && explicit_subject == null)
 		  explicit_subject = explicit_object;
-		  
+
     // @typeofof replaces instanceof
     if (attrs['typeof']) {
         var rdf_type = RDFA.CURIE.parse(attrs['typeof'], namespaces);
 
         // determine the subject of typeof, which is either explicitly given, or a new blank node.
         // note that this bnode becomes the new explicit subject of any properties and rels, too, so
-        // we are effectively updating explicit_subject 
+        // we are effectively updating explicit_subject
         // 2008-01-18 JT
         // since the explicit_subject could be an empty URI ("") which will be
         // resolved relative to the base, changed conditional
@@ -1722,7 +1722,7 @@ RDFA.traverse = function (element, subject, namespaces, lang, base, hanging) {
     if (explicit_subject != null) {
         subject = explicit_subject;
         RDFA.associateElementAndSubject(element, RDFA.triplestore.sym(explicit_subject), namespaces);
-          
+
         // complete hanging if necessary
         var hanging_result = RDFA.complete_hanging(hanging, explicit_subject);
         hanging = hanging_result.new_hanging;
@@ -1735,7 +1735,7 @@ RDFA.traverse = function (element, subject, namespaces, lang, base, hanging) {
         if (hanging_result.new_subject) {
           subject = hanging_result.new_subject;
         }
-      }      
+      }
     }
 
     // REL attribute
@@ -1747,7 +1747,7 @@ RDFA.traverse = function (element, subject, namespaces, lang, base, hanging) {
       } else {
         // we hang
         hanging = RDFA.add_hanging_rel(hanging, subject, rel_value, base, namespaces);
-      }      
+      }
     });
 
     // REV attribute
@@ -1758,10 +1758,10 @@ RDFA.traverse = function (element, subject, namespaces, lang, base, hanging) {
       } else {
         // we hang
         hanging = RDFA.add_hanging_rev(hanging, subject, rev_value, base, namespaces);
-      }      
+      }
     });
-    
-    
+
+
     // PROPERTY attribute
     // 2007-11-26 JT
     // property is a space-separated list of CURIEs
@@ -1781,19 +1781,19 @@ RDFA.traverse = function (element, subject, namespaces, lang, base, hanging) {
           }
         }
 
-        // datatype is actually a CURIE here    
+        // datatype is actually a CURIE here
         if (datatype != null) {
           datatype = RDFA.CURIE.parse(datatype, namespaces);
         }
-        
+
         // go through each prop
         RDFA.each_prefixed_attr_value(attrs['property'], function(prop_value) {
           var property = RDFA.CURIE.parse(prop_value, namespaces);
           var triple = RDFA.add_triple(base, subject, property, content, true, datatype, lang);
-          RDFA.CALLBACK_NEW_TRIPLE_WITH_LITERAL_OBJECT(element_to_callback, triple);                    
+          RDFA.CALLBACK_NEW_TRIPLE_WITH_LITERAL_OBJECT(element_to_callback, triple);
         });
     }
-    	    
+
     // if we have an explicit object, we chain
     if (explicit_object != null) {
       RDFA.associateElementAndSubject(element, explicit_object, namespaces);
@@ -1813,7 +1813,7 @@ RDFA.parse = function(parse_document, base) {
 	parse_document.RDFA = RDFA;
 	RDFA.document = parse_document;
 	RDFA.document.__RDFA_BASE = __RDFA_BASE;
-    
+
     // is there a base
 	if (typeof(base) != 'undefined')
 		RDFA.BASE = base;
@@ -1823,7 +1823,7 @@ RDFA.parse = function(parse_document, base) {
     // is it overriden by the HTML itself?
     if (parse_document.getElementsByTagName('base').length > 0)
       RDFA.BASE = parse_document.getElementsByTagName('base')[0].href;
-    
+
     // by default, the current namespace for CURIEs is vocab#
     var location = parse_document.location || document.location;
     var default_ns = new Namespace('http://www.w3.org/1999/xhtml/vocab#');
@@ -1835,7 +1835,7 @@ RDFA.parse = function(parse_document, base) {
 
     // hGRDDL for XHTML1 special needs
 //    RDFA.GRDDL.addProfile(__RDFA_BASE + 'xhtml1-hgrddl.js');
-    
+
     // do the profiles, and then traverse
     RDFA.GRDDL.runProfiles(parse_document, function() {
 //         2008-01-18 JT


### PR DESCRIPTION
Trailing whitespace is considered a Bad Idea. This patch removes all of it.

The command I used was `ruby -i -pe '$_.sub!(/\s+$/, "\n")' `git grep -lP '\s+$' | grep -vE '\.(pdf|png)$'``.
